### PR TITLE
Dismiss the tooltip on click 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cp-tooltip",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Component Description",
   "main": "build/cp-tooltip.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cp-tooltip",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Component Description",
   "main": "build/cp-tooltip.js",
   "scripts": {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -24,6 +24,7 @@ angular.module('cp-tooltip')
 				});
 
 				el.on('mouseleave.cptooltip'+id, dismissTooltip);
+				el.on('click', dismissTooltip);
 
 				/** Cleanup events **/
 				scope.$on('$destroy', function() {
@@ -32,6 +33,7 @@ angular.module('cp-tooltip')
 					clearTimeout(timeout2);
 					el.off('mouseenter.cptooltip'+id);
 					el.off('mouseleave.cptooltip'+id);
+					el.off('click');
 				});
 
 				function renderTooltip(e) {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -24,7 +24,10 @@ angular.module('cp-tooltip')
 				});
 
 				el.on('mouseleave.cptooltip'+id, dismissTooltip);
-				el.on('click', dismissTooltip);
+				
+				if(!allowInteraction){
+					el.on('click', dismissTooltip);
+				}
 
 				/** Cleanup events **/
 				scope.$on('$destroy', function() {
@@ -33,7 +36,10 @@ angular.module('cp-tooltip')
 					clearTimeout(timeout2);
 					el.off('mouseenter.cptooltip'+id);
 					el.off('mouseleave.cptooltip'+id);
-					el.off('click');
+					
+					if(!allowInteraction){ 
+						el.off('click');
+					}
 				});
 
 				function renderTooltip(e) {


### PR DESCRIPTION
Tooltip is closed on click, for cases when the parent element opens a modal. (prevents the tooltip from being shown over the modal)